### PR TITLE
Update Sportsbaren calendar feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ sportspub-ical-viewer/
 - Open: `weekly.html?pub=sportsbaren` for the weekly view.
 - Add more pubs by editing `pubs.json` and dropping a logo in `/assets/`.
 
+### Calendar feed requirements
+- Each pub entry must provide a **public** iCal feed URL that responds with a standard `.ics` file.
+- The feed should be the "basic" Google Calendar export (or similar) so the link ends with `.ics` and returns text in [RFC 5545](https://datatracker.ietf.org/doc/html/rfc5545) format.
+- Example: `https://calendar.google.com/calendar/ical/.../public/basic.ics`.
+
 ---
 
 ## 📄 License

--- a/pubs.json
+++ b/pubs.json
@@ -7,6 +7,6 @@
       "secondary": "#000000",
       "text": "#ffffff"
     },
-    "ical": "https://calendar.google.com/calendar/u/0?cid=Y182MDM0YmQ1MjI4MzU0MjY3M2Y4OGRjMjdmNTcxNmM4MGEwNmI5NjdiNGM1MDI0OTUwMzM3ZWZjZTE1YmEwZDc4QGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20"
+    "ical": "https://calendar.google.com/calendar/ical/c_6034bd52283542673f88dc27f5716c80a06b967b4c5024950337efce15ba0d78%40group.calendar.google.com/public/basic.ics"
   }
 }


### PR DESCRIPTION
## Summary
- replace the Sportsbaren calendar entry with the new public Google Calendar iCal feed
- document the expected .ics feed format in the README for future pub entries

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cd3e4936188328b22df7518ee98522