### PR TITLE
Add weekly layout and calendar rendering

### DIFF
--- a/script.js
+++ b/script.js
@@ -42,8 +42,467 @@ async function loadPubConfig() {
   document.getElementById("logo").src = pub.logo;
   document.getElementById("pub-name").textContent = pub.name;
 
-  // Placeholder: Codex will implement iCal parsing here
-  document.getElementById("events").innerHTML = "<p>Events will load here...</p>";
+  await renderEventsForView(pub);
+}
+
+async function renderEventsForView(pub) {
+  const view = document.body.dataset.view || "sidebar";
+  const eventsContainer = document.getElementById("events");
+
+  if (!eventsContainer) {
+    return;
+  }
+
+  if (!pub.ical) {
+    eventsContainer.innerHTML =
+      "<p class=\"error-message\">No calendar has been configured for this pub.</p>";
+    return;
+  }
+
+  let icsText = "";
+  try {
+    const response = await fetch(pub.ical);
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch calendar: ${response.status} ${response.statusText}`);
+    }
+
+    icsText = await response.text();
+  } catch (error) {
+    console.error("Error fetching calendar feed", error);
+    eventsContainer.innerHTML =
+      "<p class=\"error-message\">Unable to load events right now. Please try again later.</p>";
+    return;
+  }
+
+  const events = parseICalEvents(icsText);
+
+  if (view === "weekly") {
+    renderWeeklyEvents(events);
+  } else {
+    renderSidebarEvents(events);
+  }
+}
+
+function unfoldICalLines(icsText) {
+  const lines = icsText.split(/\r?\n/);
+  const unfolded = [];
+
+  for (const line of lines) {
+    if (!line) {
+      continue;
+    }
+
+    if (line.startsWith(" ") || line.startsWith("\t")) {
+      if (unfolded.length > 0) {
+        unfolded[unfolded.length - 1] += line.slice(1);
+      }
+    } else {
+      unfolded.push(line);
+    }
+  }
+
+  return unfolded;
+}
+
+function decodeICalText(value) {
+  return value
+    .replace(/\\n/g, "\n")
+    .replace(/\\,/g, ",")
+    .replace(/\\;/g, ";")
+    .replace(/\\\\/g, "\\")
+    .trim();
+}
+
+function parseICalDate(value, params = {}) {
+  const isDateValue = params.VALUE === "DATE" || /^\d{8}$/.test(value);
+
+  if (isDateValue) {
+    const year = Number(value.slice(0, 4));
+    const month = Number(value.slice(4, 6)) - 1;
+    const day = Number(value.slice(6, 8));
+    return { date: new Date(year, month, day), allDay: true };
+  }
+
+  const hasTime = value.includes("T");
+  const datePart = `${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6, 8)}`;
+  let timePart = "00:00:00";
+
+  if (hasTime) {
+    const timeIndex = value.indexOf("T") + 1;
+    const hours = value.slice(timeIndex, timeIndex + 2) || "00";
+    const minutes = value.slice(timeIndex + 2, timeIndex + 4) || "00";
+    const seconds = value.slice(timeIndex + 4, timeIndex + 6) || "00";
+    timePart = `${hours}:${minutes}:${seconds}`;
+  }
+
+  const isoDate = `${datePart}T${timePart}`;
+  if (value.endsWith("Z")) {
+    return { date: new Date(`${isoDate}Z`), allDay: false };
+  }
+
+  return { date: new Date(isoDate), allDay: false };
+}
+
+function parseICalEvents(icsText) {
+  const unfoldedLines = unfoldICalLines(icsText);
+  const events = [];
+
+  let currentEvent = null;
+
+  for (const rawLine of unfoldedLines) {
+    const line = rawLine.trim();
+
+    if (line === "BEGIN:VEVENT") {
+      currentEvent = {};
+      continue;
+    }
+
+    if (line === "END:VEVENT") {
+      if (currentEvent && currentEvent.dtstart) {
+        const startData = parseICalDate(currentEvent.dtstart.value, currentEvent.dtstart.params);
+
+        if (Number.isNaN(startData.date.getTime())) {
+          currentEvent = null;
+          continue;
+        }
+
+        let endDate = null;
+        let allDay = startData.allDay;
+
+        if (currentEvent.dtend) {
+          const endData = parseICalDate(currentEvent.dtend.value, currentEvent.dtend.params);
+          endDate = Number.isNaN(endData.date.getTime()) ? null : endData.date;
+          allDay = allDay || endData.allDay;
+
+          if (allDay && endDate) {
+            // For all-day events the DTEND is exclusive; shift back one day to keep within bounds.
+            const adjusted = new Date(endDate);
+            adjusted.setDate(adjusted.getDate() - 1);
+            adjusted.setHours(23, 59, 59, 999);
+            endDate = adjusted;
+          }
+        }
+
+        events.push({
+          title: currentEvent.summary || "Untitled Event",
+          description: currentEvent.description || "",
+          location: currentEvent.location || "",
+          start: startData.date,
+          end: endDate,
+          allDay,
+        });
+      }
+
+      currentEvent = null;
+      continue;
+    }
+
+    if (!currentEvent) {
+      continue;
+    }
+
+    const separatorIndex = line.indexOf(":");
+    if (separatorIndex === -1) {
+      continue;
+    }
+
+    const namePart = line.slice(0, separatorIndex);
+    const value = line.slice(separatorIndex + 1);
+
+    const nameSegments = namePart.split(";");
+    const property = nameSegments[0].toUpperCase();
+    const params = {};
+
+    for (let i = 1; i < nameSegments.length; i += 1) {
+      const [paramName, paramValue] = nameSegments[i].split("=");
+      if (paramName && paramValue) {
+        params[paramName.toUpperCase()] = paramValue;
+      }
+    }
+
+    switch (property) {
+      case "SUMMARY":
+        currentEvent.summary = decodeICalText(value);
+        break;
+      case "DESCRIPTION":
+        currentEvent.description = decodeICalText(value);
+        break;
+      case "LOCATION":
+        currentEvent.location = decodeICalText(value);
+        break;
+      case "DTSTART":
+        currentEvent.dtstart = { value, params };
+        break;
+      case "DTEND":
+        currentEvent.dtend = { value, params };
+        break;
+      default:
+        break;
+    }
+  }
+
+  events.sort((a, b) => a.start.getTime() - b.start.getTime());
+  return events;
+}
+
+function getStartOfDay(date) {
+  const start = new Date(date);
+  start.setHours(0, 0, 0, 0);
+  return start;
+}
+
+function getCurrentWeekRange(referenceDate = new Date()) {
+  const start = getStartOfDay(referenceDate);
+  const weekday = start.getDay();
+  const mondayIndex = (weekday + 6) % 7; // Convert Sunday=0 to Monday=0
+  start.setDate(start.getDate() - mondayIndex);
+
+  const end = new Date(start);
+  end.setDate(end.getDate() + 7);
+
+  return { start, end };
+}
+
+function formatWeekRange(start, end) {
+  const inclusiveEnd = new Date(end);
+  inclusiveEnd.setDate(inclusiveEnd.getDate() - 1);
+
+  const sameYear = start.getFullYear() === inclusiveEnd.getFullYear();
+  const sameMonth = sameYear && start.getMonth() === inclusiveEnd.getMonth();
+
+  const startOptions = { month: "short", day: "numeric" };
+  const endOptions = { month: "short", day: "numeric" };
+
+  if (sameYear && sameMonth) {
+    const startText = start.toLocaleDateString(undefined, startOptions);
+    const endText = inclusiveEnd.toLocaleDateString(undefined, { day: "numeric" });
+    return `${startText} – ${endText}, ${start.getFullYear()}`;
+  }
+
+  if (sameYear) {
+    const startText = start.toLocaleDateString(undefined, startOptions);
+    const endText = inclusiveEnd.toLocaleDateString(undefined, endOptions);
+    return `${startText} – ${endText}, ${start.getFullYear()}`;
+  }
+
+  const startText = start.toLocaleDateString(undefined, startOptions);
+  const endText = inclusiveEnd.toLocaleDateString(undefined, endOptions);
+  return `${startText} ${start.getFullYear()} – ${endText} ${inclusiveEnd.getFullYear()}`;
+}
+
+function isSameDay(a, b) {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+function formatEventTime(event, referenceDayStart) {
+  if (event.allDay) {
+    return "All day";
+  }
+
+  const startOptions = { hour: "2-digit", minute: "2-digit" };
+  const eventStart = event.start;
+  const eventEnd = event.end;
+  const startText = eventStart.toLocaleTimeString([], startOptions);
+
+  if (referenceDayStart) {
+    const dayStart = new Date(referenceDayStart);
+    dayStart.setHours(0, 0, 0, 0);
+    const dayEnd = new Date(dayStart);
+    dayEnd.setDate(dayEnd.getDate() + 1);
+
+    if (eventStart < dayStart) {
+      if (eventEnd && eventEnd > dayStart && eventEnd < dayEnd) {
+        return `Until ${eventEnd.toLocaleTimeString([], startOptions)}`;
+      }
+
+      return "Ongoing";
+    }
+
+    if (eventEnd && eventEnd > dayEnd) {
+      return `${startText} – …`;
+    }
+  }
+
+  if (eventEnd && eventEnd > eventStart) {
+    const endText = eventEnd.toLocaleTimeString([], startOptions);
+    return `${startText} – ${endText}`;
+  }
+
+  return startText;
+}
+
+function renderWeeklyEvents(events) {
+  const eventsContainer = document.getElementById("events");
+  if (!eventsContainer) {
+    return;
+  }
+
+  const { start: weekStart, end: weekEnd } = getCurrentWeekRange();
+  const weekRangeElement = document.getElementById("week-range");
+  if (weekRangeElement) {
+    weekRangeElement.textContent = formatWeekRange(weekStart, weekEnd);
+  }
+
+  const weekEvents = events.filter((event) => {
+    const eventStart = event.start;
+    const eventEnd = event.end || event.start;
+    return eventStart < weekEnd && eventEnd >= weekStart;
+  });
+
+  eventsContainer.innerHTML = "";
+
+  for (let offset = 0; offset < 7; offset += 1) {
+    const dayStart = new Date(weekStart);
+    dayStart.setDate(weekStart.getDate() + offset);
+    dayStart.setHours(0, 0, 0, 0);
+
+    const dayEnd = new Date(dayStart);
+    dayEnd.setDate(dayEnd.getDate() + 1);
+
+    const daySection = document.createElement("section");
+    daySection.className = "weekday";
+
+    if (isSameDay(dayStart, new Date())) {
+      daySection.classList.add("is-today");
+    }
+
+    const header = document.createElement("div");
+    header.className = "weekday-header";
+
+    const nameEl = document.createElement("h2");
+    nameEl.className = "weekday-name";
+    nameEl.textContent = dayStart.toLocaleDateString(undefined, { weekday: "long" });
+
+    const dateEl = document.createElement("span");
+    dateEl.className = "weekday-date";
+    dateEl.textContent = dayStart.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+
+    header.append(nameEl, dateEl);
+
+    const list = document.createElement("div");
+    list.className = "events-list";
+
+    const dayEvents = weekEvents
+      .filter((event) => {
+        const eventStart = event.start;
+        const eventEnd = event.end || event.start;
+        return eventStart < dayEnd && eventEnd >= dayStart;
+      })
+      .sort((a, b) => a.start.getTime() - b.start.getTime());
+
+    if (dayEvents.length === 0) {
+      const emptyMessage = document.createElement("p");
+      emptyMessage.className = "no-events";
+      emptyMessage.textContent = "No events";
+      list.appendChild(emptyMessage);
+    } else {
+      dayEvents.forEach((event) => {
+        const eventEl = document.createElement("article");
+        eventEl.className = "event";
+
+        const timeEl = document.createElement("time");
+        timeEl.className = "event-time";
+        timeEl.dateTime = event.start.toISOString();
+        timeEl.textContent = formatEventTime(event, dayStart);
+        eventEl.appendChild(timeEl);
+
+        const titleEl = document.createElement("h3");
+        titleEl.className = "event-title";
+        titleEl.textContent = event.title;
+        eventEl.appendChild(titleEl);
+
+        if (event.location) {
+          const locationEl = document.createElement("p");
+          locationEl.className = "event-location";
+          locationEl.textContent = event.location;
+          eventEl.appendChild(locationEl);
+        }
+
+        if (event.description) {
+          const descriptionEl = document.createElement("p");
+          descriptionEl.className = "event-description";
+          descriptionEl.textContent = event.description;
+          eventEl.appendChild(descriptionEl);
+        }
+
+        list.appendChild(eventEl);
+      });
+    }
+
+    daySection.append(header, list);
+    eventsContainer.appendChild(daySection);
+  }
+}
+
+function renderSidebarEvents(events) {
+  const eventsContainer = document.getElementById("events");
+  if (!eventsContainer) {
+    return;
+  }
+
+  const now = new Date();
+  const upcomingEvents = events.filter((event) => {
+    if (event.end) {
+      return event.end >= now;
+    }
+    return event.start >= now;
+  });
+
+  if (upcomingEvents.length === 0) {
+    eventsContainer.innerHTML = "<p class=\"no-events\">No upcoming events.</p>";
+    return;
+  }
+
+  upcomingEvents.sort((a, b) => a.start.getTime() - b.start.getTime());
+
+  const limitedEvents = upcomingEvents.slice(0, 10);
+
+  const fragment = document.createDocumentFragment();
+
+  limitedEvents.forEach((event) => {
+    const eventEl = document.createElement("article");
+    eventEl.className = "event";
+
+    const timeEl = document.createElement("time");
+    timeEl.className = "event-time";
+    timeEl.dateTime = event.start.toISOString();
+    const dateLabel = event.start.toLocaleDateString(undefined, {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+    });
+    timeEl.textContent = `${dateLabel} • ${formatEventTime(event)}`;
+    eventEl.appendChild(timeEl);
+
+    const titleEl = document.createElement("h3");
+    titleEl.className = "event-title";
+    titleEl.textContent = event.title;
+    eventEl.appendChild(titleEl);
+
+    if (event.location) {
+      const locationEl = document.createElement("p");
+      locationEl.className = "event-location";
+      locationEl.textContent = event.location;
+      eventEl.appendChild(locationEl);
+    }
+
+    if (event.description) {
+      const descriptionEl = document.createElement("p");
+      descriptionEl.className = "event-description";
+      descriptionEl.textContent = event.description;
+      eventEl.appendChild(descriptionEl);
+    }
+
+    fragment.appendChild(eventEl);
+  });
+
+  eventsContainer.innerHTML = "";
+  eventsContainer.appendChild(fragment);
 }
 
 loadPubConfig();

--- a/style.css
+++ b/style.css
@@ -17,3 +17,127 @@ header img {
 #events {
   padding: 20px;
 }
+
+.error-message {
+  background: rgba(255, 68, 68, 0.15);
+  border-left: 4px solid #ff4444;
+  padding: 12px 16px;
+  border-radius: 6px;
+  font-weight: 600;
+}
+
+.no-events {
+  margin: 0;
+  font-style: italic;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+body[data-view="weekly"] main {
+  padding: 20px 30px 40px;
+}
+
+body[data-view="weekly"] .week-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+body[data-view="weekly"] .week-header h2 {
+  margin: 0;
+  font-size: clamp(1.6rem, 2vw, 2.4rem);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+body[data-view="weekly"] #events {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 18px;
+  padding: 0;
+}
+
+body[data-view="weekly"] .weekday {
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  min-height: 260px;
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+body[data-view="weekly"] .weekday.is-today {
+  border-color: rgba(255, 255, 255, 0.35);
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.2);
+}
+
+body[data-view="weekly"] .weekday-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+body[data-view="weekly"] .weekday-name {
+  margin: 0;
+  font-size: 1.2rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+body[data-view="weekly"] .weekday-date {
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+body[data-view="weekly"] .events-list {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  flex: 1;
+}
+
+body[data-view="weekly"] .event {
+  background: rgba(0, 0, 0, 0.35);
+  border-radius: 10px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+body[data-view="weekly"] .event-time {
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+body[data-view="weekly"] .event-title {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.3;
+}
+
+body[data-view="weekly"] .event-location {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+body[data-view="weekly"] .event-description {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.7);
+  white-space: pre-line;
+}
+
+body[data-view="weekly"] .events-list .no-events {
+  text-align: center;
+  padding: 24px 0;
+}

--- a/weekly.html
+++ b/weekly.html
@@ -13,7 +13,10 @@
     <h1 id="pub-name"></h1>
   </header>
   <main>
-    <div id="events"></div>
+    <section class="week-header">
+      <h2 id="week-range">This Week</h2>
+    </section>
+    <div id="events" class="weekly-grid" aria-live="polite"></div>
   </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add structured weekly markup with a header and grid container
- style the weekly view with a responsive grid and detailed event cards
- fetch and parse iCal feeds to render weekly and sidebar events based on the active view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd3fd615388328a03d1975db6b0067