### PR TITLE
Fix Sportsbaren logo path

### DIFF
--- a/pubs.json
+++ b/pubs.json
@@ -1,7 +1,7 @@
 {
   "sportsbaren": {
     "name": "Sportsbaren",
-    "logo": "assets/sportsbaren-logo.png",
+    "logo": "assets/sportsbaren-logo-rgb.png",
     "colors": {
       "primary": "#d2242a",
       "secondary": "#000000",


### PR DESCRIPTION
## Summary
- point the Sportsbaren logo reference at the RGB asset so the image loads

## Testing
- python3 -m http.server 8000
- playwright screenshot verification


------
https://chatgpt.com/codex/tasks/task_e_68cd42fb3af4832881e862ca48c1fdcc