### PR TITLE
Skip empty days in weekly view

### DIFF
--- a/script.js
+++ b/script.js
@@ -355,6 +355,7 @@ function renderWeeklyEvents(events) {
   });
 
   eventsContainer.innerHTML = "";
+  let renderedDayCount = 0;
 
   for (let offset = 0; offset < 7; offset += 1) {
     const dayStart = new Date(weekStart);
@@ -363,6 +364,18 @@ function renderWeeklyEvents(events) {
 
     const dayEnd = new Date(dayStart);
     dayEnd.setDate(dayEnd.getDate() + 1);
+
+    const dayEvents = weekEvents
+      .filter((event) => {
+        const eventStart = event.start;
+        const eventEnd = event.end || event.start;
+        return eventStart < dayEnd && eventEnd >= dayStart;
+      })
+      .sort((a, b) => a.start.getTime() - b.start.getTime());
+
+    if (dayEvents.length === 0) {
+      continue;
+    }
 
     const daySection = document.createElement("section");
     daySection.className = "weekday";
@@ -387,55 +400,52 @@ function renderWeeklyEvents(events) {
     const list = document.createElement("div");
     list.className = "events-list";
 
-    const dayEvents = weekEvents
-      .filter((event) => {
-        const eventStart = event.start;
-        const eventEnd = event.end || event.start;
-        return eventStart < dayEnd && eventEnd >= dayStart;
-      })
-      .sort((a, b) => a.start.getTime() - b.start.getTime());
+    dayEvents.forEach((event) => {
+      const eventEl = document.createElement("article");
+      eventEl.className = "event";
 
-    if (dayEvents.length === 0) {
-      const emptyMessage = document.createElement("p");
-      emptyMessage.className = "no-events";
-      emptyMessage.textContent = "No events";
-      list.appendChild(emptyMessage);
-    } else {
-      dayEvents.forEach((event) => {
-        const eventEl = document.createElement("article");
-        eventEl.className = "event";
+      const timeEl = document.createElement("time");
+      timeEl.className = "event-time";
+      timeEl.dateTime = event.start.toISOString();
+      timeEl.textContent = formatEventTime(event, dayStart);
+      eventEl.appendChild(timeEl);
 
-        const timeEl = document.createElement("time");
-        timeEl.className = "event-time";
-        timeEl.dateTime = event.start.toISOString();
-        timeEl.textContent = formatEventTime(event, dayStart);
-        eventEl.appendChild(timeEl);
+      const titleEl = document.createElement("h3");
+      titleEl.className = "event-title";
+      titleEl.textContent = event.title;
+      eventEl.appendChild(titleEl);
 
-        const titleEl = document.createElement("h3");
-        titleEl.className = "event-title";
-        titleEl.textContent = event.title;
-        eventEl.appendChild(titleEl);
+      if (event.location) {
+        const locationEl = document.createElement("p");
+        locationEl.className = "event-location";
+        locationEl.textContent = event.location;
+        eventEl.appendChild(locationEl);
+      }
 
-        if (event.location) {
-          const locationEl = document.createElement("p");
-          locationEl.className = "event-location";
-          locationEl.textContent = event.location;
-          eventEl.appendChild(locationEl);
-        }
+      if (event.description) {
+        const descriptionEl = document.createElement("p");
+        descriptionEl.className = "event-description";
+        descriptionEl.textContent = event.description;
+        eventEl.appendChild(descriptionEl);
+      }
 
-        if (event.description) {
-          const descriptionEl = document.createElement("p");
-          descriptionEl.className = "event-description";
-          descriptionEl.textContent = event.description;
-          eventEl.appendChild(descriptionEl);
-        }
-
-        list.appendChild(eventEl);
-      });
-    }
+      list.appendChild(eventEl);
+    });
 
     daySection.append(header, list);
     eventsContainer.appendChild(daySection);
+    renderedDayCount += 1;
+  }
+
+  if (renderedDayCount === 0) {
+    eventsContainer.classList.add("is-empty");
+
+    const emptyMessage = document.createElement("p");
+    emptyMessage.className = "no-events";
+    emptyMessage.textContent = "No events scheduled this week.";
+    eventsContainer.appendChild(emptyMessage);
+  } else {
+    eventsContainer.classList.remove("is-empty");
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -56,6 +56,8 @@ body[data-view="weekly"] #events {
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 18px;
   padding: 0;
+  justify-items: center;
+  align-content: start;
 }
 
 body[data-view="weekly"] .weekday {
@@ -67,6 +69,7 @@ body[data-view="weekly"] .weekday {
   min-height: 260px;
   box-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);
   border: 1px solid rgba(255, 255, 255, 0.08);
+  width: min(100%, 320px);
 }
 
 body[data-view="weekly"] .weekday.is-today {
@@ -99,6 +102,19 @@ body[data-view="weekly"] .events-list {
   flex-direction: column;
   gap: 14px;
   flex: 1;
+}
+
+body[data-view="weekly"] #events.is-empty {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 48px 0;
+}
+
+body[data-view="weekly"] #events.is-empty .no-events {
+  font-size: 1.1rem;
+  text-align: center;
+  max-width: 360px;
 }
 
 body[data-view="weekly"] .event {
@@ -137,7 +153,3 @@ body[data-view="weekly"] .event-description {
   white-space: pre-line;
 }
 
-body[data-view="weekly"] .events-list .no-events {
-  text-align: center;
-  padding: 24px 0;
-}


### PR DESCRIPTION
## Summary
- update the weekly renderer to omit day sections with no matching events and show a single weekly fallback message instead
- tweak the weekly grid to center the remaining day cards and size them consistently when fewer days render

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd441ea0548328a9c24109877c3f56