### PR TITLE
Group sidebar events by day

### DIFF
--- a/style.css
+++ b/style.css
@@ -32,6 +32,105 @@ header img {
   color: rgba(255, 255, 255, 0.65);
 }
 
+body[data-view="sidebar"] main {
+  padding: 16px 18px 28px;
+}
+
+body[data-view="sidebar"] #events {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 0;
+}
+
+body[data-view="sidebar"] .sidebar-day {
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  padding: 14px 16px 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.3);
+}
+
+body[data-view="sidebar"] .sidebar-day.is-today {
+  border-color: rgba(255, 255, 255, 0.35);
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.2);
+}
+
+body[data-view="sidebar"] .sidebar-day-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+body[data-view="sidebar"] .sidebar-day-title {
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+body[data-view="sidebar"] .sidebar-day-date {
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.7);
+  white-space: nowrap;
+}
+
+body[data-view="sidebar"] .sidebar-event-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+body[data-view="sidebar"] .sidebar-event {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 4px 12px;
+  align-items: start;
+}
+
+body[data-view="sidebar"] .sidebar-event-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+body[data-view="sidebar"] .sidebar-event .event-time {
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+body[data-view="sidebar"] .sidebar-event .event-title {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.3;
+}
+
+body[data-view="sidebar"] .sidebar-event .event-location,
+body[data-view="sidebar"] .sidebar-event .event-description {
+  margin: 0;
+  grid-column: 2 / 3;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+body[data-view="sidebar"] .sidebar-event .event-description {
+  white-space: pre-line;
+}
+
+body[data-view="sidebar"] .sidebar-no-events {
+  margin: 0;
+  font-style: italic;
+  color: rgba(255, 255, 255, 0.6);
+}
+
 body[data-view="weekly"] main {
   padding: 20px 30px 40px;
 }


### PR DESCRIPTION
## Summary
- bucket sidebar events by calendar day and ensure the layout always includes today plus at least tomorrow
- add compact sidebar styles for day group headers and the event list

## Testing
- node - <<'NODE' (jsdom simulation verifying today and tomorrow buckets)

------
https://chatgpt.com/codex/tasks/task_e_68cd4533ae448328b8de3abfc36c441a