### PR TITLE
Add Sportsbaren theme and dynamic pub stylesheet loading

### DIFF
--- a/assets/sportsbaren.css
+++ b/assets/sportsbaren.css
@@ -1,0 +1,73 @@
+@import url("https://fonts.googleapis.com/css2?family=Barlow:wght@400;600;700&family=Staatliches&display=swap");
+
+:root {
+  --app-body-font: "Barlow", "Helvetica Neue", Arial, sans-serif;
+  --app-heading-font: "Staatliches", "Barlow", sans-serif;
+  --app-background: radial-gradient(circle at 15% 20%, rgba(210, 36, 42, 0.45), transparent 55%),
+    radial-gradient(circle at 85% 15%, rgba(18, 75, 160, 0.3), transparent 55%),
+    #040204;
+  --app-text-color: #f5f7fa;
+  --app-text-strong: rgba(245, 247, 250, 0.9);
+  --app-text-subtle: rgba(245, 247, 250, 0.75);
+  --app-text-muted: rgba(245, 247, 250, 0.7);
+  --app-text-tertiary: rgba(245, 247, 250, 0.65);
+  --app-header-background: linear-gradient(135deg, rgba(10, 10, 15, 0.95), rgba(210, 36, 42, 0.92) 80%);
+  --app-surface-background: rgba(9, 10, 16, 0.85);
+  --app-surface-border: rgba(245, 247, 250, 0.12);
+  --app-surface-highlight-border: rgba(210, 36, 42, 0.65);
+  --app-surface-highlight-ring: rgba(210, 36, 42, 0.35);
+  --app-event-background: rgba(8, 9, 16, 0.9);
+  --app-event-border: rgba(210, 36, 42, 0.45);
+  --app-event-time-color: #ffd166;
+}
+
+body {
+  background-attachment: fixed;
+  background-size: cover;
+}
+
+header {
+  box-shadow: 0 8px 24px rgba(4, 2, 4, 0.6);
+  border-bottom: 3px solid rgba(210, 36, 42, 0.45);
+}
+
+#pub-name {
+  font-size: clamp(1.8rem, 3.5vw, 2.8rem);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+header img {
+  filter: drop-shadow(0 4px 12px rgba(0, 0, 0, 0.65));
+}
+
+body[data-view="sidebar"] .sidebar-day,
+body[data-view="weekly"] .weekday {
+  backdrop-filter: blur(14px);
+}
+
+body[data-view="sidebar"] .sidebar-day-title,
+body[data-view="weekly"] .weekday-name,
+body[data-view="weekly"] .week-header h2 {
+  letter-spacing: 0.22em;
+}
+
+body[data-view="sidebar"] .sidebar-event .event-title,
+body[data-view="weekly"] .event-title {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+body[data-view="sidebar"] .sidebar-event .event-time,
+body[data-view="weekly"] .event-time {
+  font-weight: 800;
+}
+
+body[data-view="weekly"] .week-header {
+  border-bottom: 2px solid rgba(210, 36, 42, 0.35);
+  padding-bottom: 12px;
+}
+
+body[data-view="weekly"] .week-header h2 {
+  font-size: clamp(1.9rem, 2.4vw, 2.8rem);
+}

--- a/pubs.json
+++ b/pubs.json
@@ -2,6 +2,7 @@
   "sportsbaren": {
     "name": "Sportsbaren",
     "logo": "assets/sportsbaren-logo-rgb.png",
+    "theme": "assets/sportsbaren.css",
     "colors": {
       "primary": "#d2242a",
       "secondary": "#000000",

--- a/style.css
+++ b/style.css
@@ -1,18 +1,46 @@
+:root {
+  --app-body-font: "Arial", sans-serif;
+  --app-heading-font: "Arial", sans-serif;
+  --app-background: #000000;
+  --app-text-color: #ffffff;
+  --app-header-background: #111111;
+  --app-surface-background: rgba(255, 255, 255, 0.06);
+  --app-surface-border: rgba(255, 255, 255, 0.08);
+  --app-surface-highlight-border: rgba(255, 255, 255, 0.35);
+  --app-surface-highlight-ring: rgba(255, 255, 255, 0.2);
+  --app-text-strong: rgba(255, 255, 255, 0.85);
+  --app-text-subtle: rgba(255, 255, 255, 0.7);
+  --app-text-muted: rgba(255, 255, 255, 0.65);
+  --app-text-tertiary: rgba(255, 255, 255, 0.6);
+  --app-text-soft: rgba(255, 255, 255, 0.75);
+  --app-event-background: rgba(0, 0, 0, 0.35);
+  --app-event-border: rgba(255, 255, 255, 0.08);
+  --app-event-time-color: rgba(255, 255, 255, 0.85);
+}
+
 body {
   margin: 0;
-  font-family: Arial, sans-serif;
-  background: #000;
-  color: #fff;
+  font-family: var(--app-body-font, Arial, sans-serif);
+  background: var(--app-background, #000);
+  color: var(--app-text-color, #fff);
 }
 header {
   display: flex;
   align-items: center;
   padding: 10px;
-  background: #111;
+  background: var(--app-header-background, #111);
 }
 header img {
   height: 50px;
   margin-right: 15px;
+}
+#pub-name,
+body[data-view="sidebar"] .sidebar-day-title,
+body[data-view="weekly"] .weekday-name,
+body[data-view="weekly"] .week-header h2,
+body[data-view="sidebar"] .sidebar-event .event-title,
+body[data-view="weekly"] .event-title {
+  font-family: var(--app-heading-font, var(--app-body-font, Arial, sans-serif));
 }
 #events {
   padding: 20px;
@@ -29,7 +57,7 @@ header img {
 .no-events {
   margin: 0;
   font-style: italic;
-  color: rgba(255, 255, 255, 0.65);
+  color: var(--app-text-muted, rgba(255, 255, 255, 0.65));
 }
 
 body[data-view="sidebar"] main {
@@ -44,16 +72,16 @@ body[data-view="sidebar"] #events {
 }
 
 body[data-view="sidebar"] .sidebar-day {
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--app-surface-background, rgba(255, 255, 255, 0.06));
   border-radius: 12px;
   padding: 14px 16px 16px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--app-surface-border, rgba(255, 255, 255, 0.08));
   box-shadow: 0 6px 14px rgba(0, 0, 0, 0.3);
 }
 
 body[data-view="sidebar"] .sidebar-day.is-today {
-  border-color: rgba(255, 255, 255, 0.35);
-  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.2);
+  border-color: var(--app-surface-highlight-border, rgba(255, 255, 255, 0.35));
+  box-shadow: 0 0 0 2px var(--app-surface-highlight-ring, rgba(255, 255, 255, 0.2));
 }
 
 body[data-view="sidebar"] .sidebar-day-heading {
@@ -73,7 +101,7 @@ body[data-view="sidebar"] .sidebar-day-title {
 
 body[data-view="sidebar"] .sidebar-day-date {
   font-size: 0.95rem;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--app-text-subtle, rgba(255, 255, 255, 0.7));
   white-space: nowrap;
 }
 
@@ -104,7 +132,7 @@ body[data-view="sidebar"] .sidebar-event .event-time {
   letter-spacing: 0.04em;
   text-transform: uppercase;
   font-size: 0.95rem;
-  color: rgba(255, 255, 255, 0.85);
+  color: var(--app-event-time-color, rgba(255, 255, 255, 0.85));
 }
 
 body[data-view="sidebar"] .sidebar-event .event-title {
@@ -118,7 +146,7 @@ body[data-view="sidebar"] .sidebar-event .event-description {
   margin: 0;
   grid-column: 2 / 3;
   font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--app-text-subtle, rgba(255, 255, 255, 0.7));
 }
 
 body[data-view="sidebar"] .sidebar-event .event-description {
@@ -128,7 +156,7 @@ body[data-view="sidebar"] .sidebar-event .event-description {
 body[data-view="sidebar"] .sidebar-no-events {
   margin: 0;
   font-style: italic;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--app-text-tertiary, rgba(255, 255, 255, 0.6));
 }
 
 body[data-view="weekly"] main {
@@ -160,20 +188,20 @@ body[data-view="weekly"] #events {
 }
 
 body[data-view="weekly"] .weekday {
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--app-surface-background, rgba(255, 255, 255, 0.06));
   border-radius: 12px;
   padding: 18px;
   display: flex;
   flex-direction: column;
   min-height: 260px;
   box-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--app-surface-border, rgba(255, 255, 255, 0.08));
   width: min(100%, 320px);
 }
 
 body[data-view="weekly"] .weekday.is-today {
-  border-color: rgba(255, 255, 255, 0.35);
-  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.2);
+  border-color: var(--app-surface-highlight-border, rgba(255, 255, 255, 0.35));
+  box-shadow: 0 0 0 2px var(--app-surface-highlight-ring, rgba(255, 255, 255, 0.2));
 }
 
 body[data-view="weekly"] .weekday-header {
@@ -193,7 +221,7 @@ body[data-view="weekly"] .weekday-name {
 
 body[data-view="weekly"] .weekday-date {
   font-size: 0.95rem;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--app-text-subtle, rgba(255, 255, 255, 0.7));
 }
 
 body[data-view="weekly"] .events-list {
@@ -217,20 +245,20 @@ body[data-view="weekly"] #events.is-empty .no-events {
 }
 
 body[data-view="weekly"] .event {
-  background: rgba(0, 0, 0, 0.35);
+  background: var(--app-event-background, rgba(0, 0, 0, 0.35));
   border-radius: 10px;
   padding: 12px 14px;
   display: flex;
   flex-direction: column;
   gap: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--app-event-border, rgba(255, 255, 255, 0.08));
 }
 
 body[data-view="weekly"] .event-time {
   font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.85);
+  color: var(--app-event-time-color, rgba(255, 255, 255, 0.85));
 }
 
 body[data-view="weekly"] .event-title {
@@ -242,13 +270,13 @@ body[data-view="weekly"] .event-title {
 body[data-view="weekly"] .event-location {
   margin: 0;
   font-size: 0.95rem;
-  color: rgba(255, 255, 255, 0.75);
+  color: var(--app-text-soft, rgba(255, 255, 255, 0.75));
 }
 
 body[data-view="weekly"] .event-description {
   margin: 0;
   font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--app-text-subtle, rgba(255, 255, 255, 0.7));
   white-space: pre-line;
 }
 


### PR DESCRIPTION
## Summary
- add a theming system based on CSS variables and loadable pub stylesheets
- create the Sportsbaren brand stylesheet with custom fonts, colors, and surfaces
- load the correct theme in script.js and fall back to color variables when no theme is specified

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd47d7c6a48328ae7865a54b73fb64