### PR TITLE
Localize UI strings to Norwegian

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="nb">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Sportspub iCal Viewer - Sidebar</title>
+  <title>Sportspub iCal-visning – Sidepanel</title>
   <link rel="stylesheet" href="style.css">
   <script src="script.js" defer></script>
 </head>
 <body data-view="sidebar">
   <header>
-    <img id="logo" alt="Pub Logo">
+    <img id="logo" alt="Pub-logo">
     <h1 id="pub-name"></h1>
   </header>
   <main>

--- a/weekly.html
+++ b/weekly.html
@@ -1,20 +1,20 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="nb">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Sportspub iCal Viewer - Weekly</title>
+  <title>Sportspub iCal-visning – Ukeoversikt</title>
   <link rel="stylesheet" href="style.css">
   <script src="script.js" defer></script>
 </head>
 <body data-view="weekly">
   <header>
-    <img id="logo" alt="Pub Logo">
+    <img id="logo" alt="Pub-logo">
     <h1 id="pub-name"></h1>
   </header>
   <main>
     <section class="week-header">
-      <h2 id="week-range">This Week</h2>
+      <h2 id="week-range">Denne uken</h2>
     </section>
     <div id="events" class="weekly-grid" aria-live="polite"></div>
   </main>


### PR DESCRIPTION
## Summary
- set the HTML language, titles, and alt-tekst in the sidebar and weekly views to Norwegian
- translate all hard-coded UI meldinger in the script to Norwegian and update logging copy
- use nb-NO locale-aware date and time formatting helpers so weekday and month names render in Norwegian

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cd4f7e251c8328bf429e8402113fe7